### PR TITLE
Stop exporting SceneNode and RootNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobexd/typings",
-  "version": "20.1.0",
+  "version": "20.2.0",
   "typings": "./types/index.d.ts",
   "description": "Typings for Adobe XD CC",
   "repository": {

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -1,4 +1,46 @@
-import {Color, SceneNode} from "scenegraph";
+import { Color, SceneNode, RootNode } from "scenegraph";
+
+interface EditSettings {
+    /**
+     * Used as the Undo label in the **Edit** menu. If unspecified, XD uses the `uxp-edit-label` attribute on the DOM node which the user interacted with, and if that does not exist then the plugin's name will be used.
+     */
+    editLabel?: string;
+    /**
+     * If two consecutive edits to the same selection have the same `mergeId`, they are flattened together into one Undo step. If unspecified, for "high frequency" UI events (see above), XD treats the originating DOM node as a unique identifier for merging; for other UI events, merging is disabled.
+     */
+    mergeId?: string;
+}
+
+/**
+ * Call `editDocument()` from a plugin panel UI event listener to initiate an edit operation batch in order to modify the XD document. This API is irrelevant for plugin menu item commands, which are wrapped in an edit batch automatically.
+ *
+ * XD calls the `editFunction()` synchronously (before `editDocument()` returns). This function is treated the same as a menu command handler:
+ * 
+ * * It is passed two arguments, the selection and the root node of the scenegraph
+ * * It can return a Promise to extend the duration of the edit asynchronously
+ * 
+ * You can only call `editDocument()` in response to a user action, such as a button `"click"` event or a text input's `"input"` event. This generally means you must call it while a UI event handler is on the call stack.
+ * 
+ * For UI events that often occur in rapid-fire clusters, such as dragging a slider or pressing keys in a text field, XD tries to smartly merge consecutive edits into a single atomic Undo step. See the `mergeId` option below to customize this behavior.
+ * @param editFunction Function which will perform your plugin's edits to the scenegraph.
+ */
+export function editDocument(editFunction: (selection: Selection, root: RootNode) => Promise<any> | void): void;
+
+/**
+ * Call `editDocument()` from a plugin panel UI event listener to initiate an edit operation batch in order to modify the XD document. This API is irrelevant for plugin menu item commands, which are wrapped in an edit batch automatically.
+ *
+ * XD calls the `editFunction()` synchronously (before `editDocument()` returns). This function is treated the same as a menu command handler:
+ * 
+ * * It is passed two arguments, the selection and the root node of the scenegraph
+ * * It can return a Promise to extend the duration of the edit asynchronously
+ * 
+ * You can only call `editDocument()` in response to a user action, such as a button `"click"` event or a text input's `"input"` event. This generally means you must call it while a UI event handler is on the call stack.
+ * 
+ * For UI events that often occur in rapid-fire clusters, such as dragging a slider or pressing keys in a text field, XD tries to smartly merge consecutive edits into a single atomic Undo step. See the `mergeId` option below to customize this behavior.
+ * @param options Optional settings object (see below). This argument can be omitted.
+ * @param editFunction Function which will perform your plugin's edits to the scenegraph.
+ */
+export function editDocument(options: EditSettings, editFunction: (selection: Selection, root: RootNode) => Promise<any> | void): void;
 
 /**
  * All rendition settings fields are required (for a given rendition type) unless otherwise specified.
@@ -57,6 +99,13 @@ type RenditionResult = {
  * @return Promise<Array<RenditionResult>, string> - Promise which is fulfilled with an array of RenditionResults (pointing to the same outputFiles that were originally passed in, or rejected with an error string if one or more renditions failed for any reason.
  */
 export function createRenditions(renditions: RenditionSettings[]): Promise<RenditionResult[] | string>;
+
+export const RenditionType: {
+    readonly JPG: object,
+    readonly PNG: object,
+    readonly PDF: object,
+    readonly SVG: object,
+}
 
 /**
  * Adobe XD version number in the form "major.minor.patch.build"

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -101,11 +101,11 @@ type RenditionResult = {
  */
 export function createRenditions(renditions: RenditionSettings[]): Promise<RenditionResult[] | string>;
 
-export const RenditionType: {
-    readonly JPG: object,
-    readonly PNG: object,
-    readonly PDF: object,
-    readonly SVG: object,
+export enum RenditionType {
+    JPG = "jpg",
+    PNG = "png",
+    PDF = "pdf",
+    SVG = "svg",
 }
 
 /**

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -1,4 +1,5 @@
 import { Color, SceneNode, RootNode } from "scenegraph";
+import { storage } from "uxp";
 
 interface EditSettings {
     /**
@@ -53,7 +54,7 @@ type RenditionSettings = {
     /**
      * File to save the rendition to (overwritten without warning if it already exists)
      */
-    outputFile: File;
+    outputFile: storage.File;
     /**
      * File type: RenditionType.PNG, JPG, PDF, or SVG
      */
@@ -87,7 +88,7 @@ type RenditionResult = {
     /**
      * File the rendition was written to (equal to outputFile in RenditionSettings)
      */
-    outputFile: File;
+    outputFile: storage.File;
 }
 
 /**

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -43,10 +43,7 @@ export function editDocument(editFunction: (selection: Selection, root: RootNode
  */
 export function editDocument(options: EditSettings, editFunction: (selection: Selection, root: RootNode) => Promise<any> | void): void;
 
-/**
- * All rendition settings fields are required (for a given rendition type) unless otherwise specified.
- */
-type RenditionSettings = {
+interface RenditionSettingsBase {
     /**
      * Root of scenegraph subtree to render. This may be any node in the scenegraph, regardless of the current edit context.
      */
@@ -55,31 +52,63 @@ type RenditionSettings = {
      * File to save the rendition to (overwritten without warning if it already exists)
      */
     outputFile: storage.File;
-    /**
-     * File type: RenditionType.PNG, JPG, PDF, or SVG
-     */
-    type: string;
+}
+
+interface RenditionSettingsPNGorJPG extends RenditionSettingsBase {
     /**
      * (PNG & JPG renditions) DPI multipler in the range [0.1, 100], e.g. 2.0 for @2x DPI.
      */
-    scale?: number;
-    /**
-     * (JPG renditions) Compression quality in the range [1, 100].
-     */
-    quality?: number;
+    scale: number;
     /**
      * (PNG & JPEG renditions) Alpha component ignored for JPG. Optional: defaults to transparent for PNG, solid white for JPG.
      */
     background?: Color;
+}
+
+export interface RenditionSettingsPNG extends RenditionSettingsPNGorJPG {
+    /**
+     * File type
+     */
+    type: RenditionType.PNG;
+}
+
+export interface RenditionSettingsJPG extends RenditionSettingsPNGorJPG {
+    /**
+     * File type.
+     */
+    type: RenditionType.JPG;
+    /**
+     * (JPG renditions) Compression quality in the range [1, 100].
+     */
+    quality: number;
+}
+
+export interface RenditionSettingsSVG extends RenditionSettingsBase {
+    /**
+     * File type.
+     */
+    type: RenditionType.SVG;
     /**
      * (SVG renditions) If true, SVG code is minified.
      */
-    minify?: boolean;
+    minify: boolean;
     /**
      * (SVG renditions) If true, bitmap images are stored as base64 data inside the SVG file. If false, bitmap images are saved as separate files linked from the SVG code.
      */
-    embedImages?: boolean;
+    embedImages: boolean;
 }
+
+export interface RenditionSettingsPDF extends RenditionSettingsBase {
+    /**
+     * File type
+     */
+    type: RenditionType.PDF;
+}
+
+/**
+ * All rendition settings fields are required (for a given rendition type) unless otherwise specified.
+ */
+export type RenditionSettings = RenditionSettingsPNG | RenditionSettingsJPG | RenditionSettingsSVG | RenditionSettingsPDF;
 
 /**
  * Type that gets returned by `application.createRenditions`

--- a/types/application.d.ts
+++ b/types/application.d.ts
@@ -62,23 +62,23 @@ type RenditionSettings = {
     /**
      * (PNG & JPG renditions) DPI multipler in the range [0.1, 100], e.g. 2.0 for @2x DPI.
      */
-    scale: number;
+    scale?: number;
     /**
      * (JPG renditions) Compression quality in the range [1, 100].
      */
-    quality: number;
+    quality?: number;
     /**
      * (PNG & JPEG renditions) Alpha component ignored for JPG. Optional: defaults to transparent for PNG, solid white for JPG.
      */
-    background: Color;
+    background?: Color;
     /**
      * (SVG renditions) If true, SVG code is minified.
      */
-    minify: boolean;
+    minify?: boolean;
     /**
      * (SVG renditions) If true, bitmap images are stored as base64 data inside the SVG file. If false, bitmap images are saved as separate files linked from the SVG code.
      */
-    embedImages: boolean;
+    embedImages?: boolean;
 }
 
 /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import {Artboard, SceneNode} from "./scenegraph";
+import { Artboard, SceneNode } from "./scenegraph";
 
 declare global {
     /**
@@ -7,7 +7,42 @@ declare global {
      */
     function require(module: string): void;
 
-    let module: {exports:any};
+    let module: { exports: any };
+
+    /**
+     * Represents the children of a scenenode. Typically accessed via the SceneNode.children property.
+     */
+    interface SceneNodeList {
+        items: SceneNode[];
+        readonly length: number;
+
+        forEach(
+            callback: (sceneNode: SceneNode, index: number) => void,
+            thisArg?: object
+        ): void;
+
+        forEachRight(
+            callback: (sceneNode: SceneNode, index: number) => void,
+            thisArg?: object
+        ): void;
+
+        filter(
+            callback: (sceneNode: SceneNode, index: number) => boolean,
+            thisArg?: object
+        ): Array<SceneNode>;
+
+        map(
+            callback: (sceneNode: SceneNode, index: number) => any,
+            thisArg?: object
+        ): Array<any>;
+
+        some(
+            callback: (sceneNode: SceneNode, index: number) => boolean,
+            thisArg?: object
+        ): boolean;
+
+        at(index: number): SceneNode | null;
+    }
 
     /**
      * The selection object represents the currently selected set of nodes in the UI. You can set the selection to use it as input for commands, or to determine what is left selected for the user when your plugin’s edit operation completes.

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -10,41 +10,6 @@ declare interface ScaleFactor {
     scaleY: number;
 }
 
-/**
- * Represents the children of a scenenode. Typically accessed via the SceneNode.children property.
- */
-declare interface SceneNodeList {
-    items: SceneNode[];
-    readonly length: number;
-
-    forEach(
-        callback: (sceneNode: SceneNode, index: number) => void,
-        thisArg?: object
-    ): void;
-
-    forEachRight(
-        callback: (sceneNode: SceneNode, index: number) => void,
-        thisArg?: object
-    ): void;
-
-    filter(
-        callback: (sceneNode: SceneNode, index: number) => boolean,
-        thisArg?: object
-    ): Array<SceneNode>;
-
-    map(
-        callback: (sceneNode: SceneNode, index: number) => any,
-        thisArg?: object
-    ): Array<any>;
-
-    some(
-        callback: (sceneNode: SceneNode, index: number) => boolean,
-        thisArg?: object
-    ): boolean;
-
-    at(index: number): SceneNode| null;
-}
-
 export class Matrix {
     /**
      * Creates a new transform matrix with the following structure:

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -14,35 +14,35 @@ declare interface ScaleFactor {
  * Represents the children of a scenenode. Typically accessed via the SceneNode.children property.
  */
 declare interface SceneNodeList {
-    items: SceneNodeClass[];
+    items: SceneNode[];
     readonly length: number;
 
     forEach(
-        callback: (sceneNode: SceneNodeClass, index: number) => void,
+        callback: (sceneNode: SceneNode, index: number) => void,
         thisArg?: object
     ): void;
 
     forEachRight(
-        callback: (sceneNode: SceneNodeClass, index: number) => void,
+        callback: (sceneNode: SceneNode, index: number) => void,
         thisArg?: object
     ): void;
 
     filter(
-        callback: (sceneNode: SceneNodeClass, index: number) => boolean,
+        callback: (sceneNode: SceneNode, index: number) => boolean,
         thisArg?: object
-    ): Array<SceneNodeClass>;
+    ): Array<SceneNode>;
 
     map(
-        callback: (sceneNode: SceneNodeClass, index: number) => any,
+        callback: (sceneNode: SceneNode, index: number) => any,
         thisArg?: object
     ): Array<any>;
 
     some(
-        callback: (sceneNode: SceneNodeClass, index: number) => boolean,
+        callback: (sceneNode: SceneNode, index: number) => boolean,
         thisArg?: object
     ): boolean;
 
-    at(index: number): SceneNodeClass | null;
+    at(index: number): SceneNode| null;
 }
 
 export class Matrix {
@@ -446,7 +446,7 @@ declare abstract class SceneNodeClass {
     /**
      * Returns the parent node. Null if this is the root node, or a freshly constructed node which has not been added to a parent yet.
      */
-    readonly parent: SceneNodeClass | null;
+    readonly parent: SceneNode| null;
     /**
      * Returns a list of this node’s children. List is length 0 if the node has no children. The first child is lowest in the z order.
      * This list is not an Array, so you must use at(i) instead of [i] to access children by index. It has a number of Array-like methods such as forEach() for convenience, however.
@@ -631,7 +631,7 @@ declare abstract class SceneNodeClass {
 /**
  * Base class for nodes that have a stroke and/or fill. This includes leaf nodes such as Rectangle, as well as BooleanGroup which is a container node. If you create a shape node, it will not be visible unless you explicitly give it either a stroke or a fill.
  */
-export class GraphicNode extends SceneNodeClass {
+export class GraphicNode extends SceneNode{
     /**
      * The fill applied to this shape, if any. If this property is null or fillEnabled is false, no fill is drawn. Freshly created nodes have no fill by default.
      *
@@ -763,10 +763,10 @@ export class Artboard extends GraphicNode {
      * May include interactions that are impossible to trigger because the trigger node (or one of its ancestors) has `visible` = false.
      *
      * Note: currently, this API excludes any applicable keyboard/gamepad interactions.
-     * @see SceneNodeClass.triggeredInteractions
+     * @see SceneNode.triggeredInteractions
      * @see interactions.allInteractions
      */
-    readonly incomingInteractions: Array<{ triggerNode: SceneNodeClass, interactions: Array<Interaction> }>;
+    readonly incomingInteractions: Array<{ triggerNode: SceneNode, interactions: Array<Interaction> }>;
 
     /**
      * **Since**: XD 19
@@ -779,24 +779,24 @@ export class Artboard extends GraphicNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -978,24 +978,24 @@ export class BooleanGroup extends GraphicNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1172,32 +1172,32 @@ export class Text extends GraphicNode {
  *
  * In a Mask Group, the mask shape is included in the group’s children list, at the top of the z order. It is not visible - only its path outline is used, for clipping the group.
  */
-export class Group extends SceneNodeClass {
+export class Group extends SceneNode{
     /**
      * The mask shape applied to this group, if any. This object is also present in the group’s children list. Though it has no direct visual appearance of its own, the mask affects the entire groups’s appearance by clipping all its other content.
      */
-    readonly mask: SceneNodeClass | null;
+    readonly mask: SceneNode| null;
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1216,7 +1216,7 @@ export class Group extends SceneNodeClass {
  *
  * It is not currently possible for plugins to *create* a new component definition or a new SymbolInstance node, aside from using `require('commands').duplicate` to clone existing SymbolInstances.
  */
-export class SymbolInstance extends SceneNodeClass {
+export class SymbolInstance extends SceneNode{
     /**
      * An identifier unique within this document that is shared by all instances of the same component.
      */
@@ -1230,24 +1230,24 @@ export class SymbolInstance extends SceneNodeClass {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1260,7 +1260,7 @@ export class SymbolInstance extends SceneNodeClass {
  * Each grid cell is a Group that is an immediate child of the RepeatGrid. These groups are automatically created and destroyed as needed when the RepeatGrid is resized.
  * It is not currently possible for plugins to create a new RepeatGrid node, aside from using commands.duplicate to clone existing RepeatGrids.
  */
-export class RepeatGrid extends SceneNodeClass {
+export class RepeatGrid extends SceneNode{
     /**
      * Defines size of the RepeatGrid. Cells are created and destroyed as necessary to fill the current size. Cells that only partially fit will be clipped.
      */
@@ -1318,24 +1318,24 @@ export class RepeatGrid extends SceneNodeClass {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1346,7 +1346,7 @@ export class RepeatGrid extends SceneNodeClass {
 /**
  * Container node whose content is linked to an external resource, such as Creative Cloud Libraries. It cannot be edited except by first ungrouping it, breaking this link.
  */
-export class LinkedGraphic extends SceneNodeClass {
+export class LinkedGraphic extends SceneNode{
 }
 
 export interface RootNode extends RootNodeClass {}
@@ -1354,27 +1354,27 @@ export interface RootNode extends RootNodeClass {}
 /**
  * Class representing the root node of the document. All Artboards are children of this node, as well as any pasteboard content that does not lie within an Artboard. Artboards must be grouped contiguously at the bottom of this node’s z order. The root node has no visual appearance of its own.
  */
-declare class RootNodeClass extends SceneNodeClass {
+declare class RootNodeClass extends SceneNode{
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNode} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNodeClass, index?: number): void;
+    addChild(node: SceneNode, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNodeClass} node Child to add
-     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
+     * @param {SceneNode} node Child to add
+     * @param {SceneNode} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
+    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1392,6 +1392,6 @@ export const selection: SceneNodeList;
  * **Since:** XD 14
  * Root node of the current document's scenegraph. Also available as the second argument passed to your plugin command handler function.
  */
-export const root: RootNodeClass;
+export const root: RootNode;
 
 export {};

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -884,7 +884,7 @@ export class Line extends GraphicNode {
      * @param {number} endX
      * @param {number} endY
      */
-    setSTartEnd(
+    setStartEnd(
         startX: number,
         startY: number,
         endX: number,

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -1,4 +1,5 @@
-import {Interaction} from 'interactions';
+import { Interaction } from 'interactions';
+import { storage } from 'uxp';
 
 declare interface Point {
     x: number;
@@ -308,7 +309,7 @@ export class ImageFill {
      *
      * @param fileOrDataURI File object pointing to an image file; or a string containing a data: URI with a base-64 encoded image.
      */
-    constructor(fileOrDataURI: string | File);
+    constructor(fileOrDataURI: string | storage.File);
 
     /**
      * @returns a new copy of this ImageFill.
@@ -398,7 +399,7 @@ export interface Bounds {
     height: number;
 }
 
-export interface SceneNode extends SceneNodeClass {}
+export interface SceneNode extends SceneNodeClass { }
 
 /**
  * Base class of all scenegraph nodes. Nodes will always be an instance of some subclass of SceneNode.
@@ -411,7 +412,7 @@ declare abstract class SceneNodeClass {
     /**
      * Returns the parent node. Null if this is the root node, or a freshly constructed node which has not been added to a parent yet.
      */
-    readonly parent: SceneNode| null;
+    readonly parent: SceneNode | null;
     /**
      * Returns a list of this node’s children. List is length 0 if the node has no children. The first child is lowest in the z order.
      * This list is not an Array, so you must use at(i) instead of [i] to access children by index. It has a number of Array-like methods such as forEach() for convenience, however.
@@ -1137,11 +1138,11 @@ export class Text extends GraphicNode {
  *
  * In a Mask Group, the mask shape is included in the group’s children list, at the top of the z order. It is not visible - only its path outline is used, for clipping the group.
  */
-export class Group extends SceneNodeClass{
+export class Group extends SceneNodeClass {
     /**
      * The mask shape applied to this group, if any. This object is also present in the group’s children list. Though it has no direct visual appearance of its own, the mask affects the entire groups’s appearance by clipping all its other content.
      */
-    readonly mask: SceneNode| null;
+    readonly mask: SceneNode | null;
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
@@ -1181,7 +1182,7 @@ export class Group extends SceneNodeClass{
  *
  * It is not currently possible for plugins to *create* a new component definition or a new SymbolInstance node, aside from using `require('commands').duplicate` to clone existing SymbolInstances.
  */
-export class SymbolInstance extends SceneNodeClass{
+export class SymbolInstance extends SceneNodeClass {
     /**
      * An identifier unique within this document that is shared by all instances of the same component.
      */
@@ -1225,7 +1226,7 @@ export class SymbolInstance extends SceneNodeClass{
  * Each grid cell is a Group that is an immediate child of the RepeatGrid. These groups are automatically created and destroyed as needed when the RepeatGrid is resized.
  * It is not currently possible for plugins to create a new RepeatGrid node, aside from using commands.duplicate to clone existing RepeatGrids.
  */
-export class RepeatGrid extends SceneNodeClass{
+export class RepeatGrid extends SceneNodeClass {
     /**
      * Defines size of the RepeatGrid. Cells are created and destroyed as necessary to fill the current size. Cells that only partially fit will be clipped.
      */
@@ -1311,15 +1312,15 @@ export class RepeatGrid extends SceneNodeClass{
 /**
  * Container node whose content is linked to an external resource, such as Creative Cloud Libraries. It cannot be edited except by first ungrouping it, breaking this link.
  */
-export class LinkedGraphic extends SceneNodeClass{
+export class LinkedGraphic extends SceneNodeClass {
 }
 
-export interface RootNode extends RootNodeClass {}
+export interface RootNode extends RootNodeClass { }
 
 /**
  * Class representing the root node of the document. All Artboards are children of this node, as well as any pasteboard content that does not lie within an Artboard. Artboards must be grouped contiguously at the bottom of this node’s z order. The root node has no visual appearance of its own.
  */
-declare class RootNodeClass extends SceneNodeClass{
+declare class RootNodeClass extends SceneNodeClass {
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
      * @param {SceneNode} node Child to add
@@ -1359,4 +1360,4 @@ export const selection: SceneNodeList;
  */
 export const root: RootNode;
 
-export {};
+export { };

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -596,7 +596,7 @@ declare abstract class SceneNodeClass {
 /**
  * Base class for nodes that have a stroke and/or fill. This includes leaf nodes such as Rectangle, as well as BooleanGroup which is a container node. If you create a shape node, it will not be visible unless you explicitly give it either a stroke or a fill.
  */
-export class GraphicNode extends SceneNode{
+export class GraphicNode extends SceneNodeClass {
     /**
      * The fill applied to this shape, if any. If this property is null or fillEnabled is false, no fill is drawn. Freshly created nodes have no fill by default.
      *
@@ -1137,7 +1137,7 @@ export class Text extends GraphicNode {
  *
  * In a Mask Group, the mask shape is included in the group’s children list, at the top of the z order. It is not visible - only its path outline is used, for clipping the group.
  */
-export class Group extends SceneNode{
+export class Group extends SceneNodeClass{
     /**
      * The mask shape applied to this group, if any. This object is also present in the group’s children list. Though it has no direct visual appearance of its own, the mask affects the entire groups’s appearance by clipping all its other content.
      */
@@ -1181,7 +1181,7 @@ export class Group extends SceneNode{
  *
  * It is not currently possible for plugins to *create* a new component definition or a new SymbolInstance node, aside from using `require('commands').duplicate` to clone existing SymbolInstances.
  */
-export class SymbolInstance extends SceneNode{
+export class SymbolInstance extends SceneNodeClass{
     /**
      * An identifier unique within this document that is shared by all instances of the same component.
      */
@@ -1225,7 +1225,7 @@ export class SymbolInstance extends SceneNode{
  * Each grid cell is a Group that is an immediate child of the RepeatGrid. These groups are automatically created and destroyed as needed when the RepeatGrid is resized.
  * It is not currently possible for plugins to create a new RepeatGrid node, aside from using commands.duplicate to clone existing RepeatGrids.
  */
-export class RepeatGrid extends SceneNode{
+export class RepeatGrid extends SceneNodeClass{
     /**
      * Defines size of the RepeatGrid. Cells are created and destroyed as necessary to fill the current size. Cells that only partially fit will be clipped.
      */
@@ -1311,7 +1311,7 @@ export class RepeatGrid extends SceneNode{
 /**
  * Container node whose content is linked to an external resource, such as Creative Cloud Libraries. It cannot be edited except by first ungrouping it, breaking this link.
  */
-export class LinkedGraphic extends SceneNode{
+export class LinkedGraphic extends SceneNodeClass{
 }
 
 export interface RootNode extends RootNodeClass {}
@@ -1319,7 +1319,7 @@ export interface RootNode extends RootNodeClass {}
 /**
  * Class representing the root node of the document. All Artboards are children of this node, as well as any pasteboard content that does not lie within an Artboard. Artboards must be grouped contiguously at the bottom of this node’s z order. The root node has no visual appearance of its own.
  */
-declare class RootNodeClass extends SceneNode{
+declare class RootNodeClass extends SceneNodeClass{
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
      * @param {SceneNode} node Child to add

--- a/types/scenegraph.d.ts
+++ b/types/scenegraph.d.ts
@@ -14,35 +14,35 @@ declare interface ScaleFactor {
  * Represents the children of a scenenode. Typically accessed via the SceneNode.children property.
  */
 declare interface SceneNodeList {
-    items: SceneNode[];
+    items: SceneNodeClass[];
     readonly length: number;
 
     forEach(
-        callback: (sceneNode: SceneNode, index: number) => void,
+        callback: (sceneNode: SceneNodeClass, index: number) => void,
         thisArg?: object
     ): void;
 
     forEachRight(
-        callback: (sceneNode: SceneNode, index: number) => void,
+        callback: (sceneNode: SceneNodeClass, index: number) => void,
         thisArg?: object
     ): void;
 
     filter(
-        callback: (sceneNode: SceneNode, index: number) => boolean,
+        callback: (sceneNode: SceneNodeClass, index: number) => boolean,
         thisArg?: object
-    ): Array<SceneNode>;
+    ): Array<SceneNodeClass>;
 
     map(
-        callback: (sceneNode: SceneNode, index: number) => any,
+        callback: (sceneNode: SceneNodeClass, index: number) => any,
         thisArg?: object
     ): Array<any>;
 
     some(
-        callback: (sceneNode: SceneNode, index: number) => boolean,
+        callback: (sceneNode: SceneNodeClass, index: number) => boolean,
         thisArg?: object
     ): boolean;
 
-    at(index: number): SceneNode | null;
+    at(index: number): SceneNodeClass | null;
 }
 
 export class Matrix {
@@ -433,10 +433,12 @@ export interface Bounds {
     height: number;
 }
 
+export interface SceneNode extends SceneNodeClass {}
+
 /**
  * Base class of all scenegraph nodes. Nodes will always be an instance of some subclass of SceneNode.
  */
-export abstract class SceneNode {
+declare abstract class SceneNodeClass {
     /**
      * Returns a unique identifier for this node that stays the same when the file is closed & reopened, or if the node is moved to a different part of the document. Cut-Paste will result in a new guid, however.
      */
@@ -444,7 +446,7 @@ export abstract class SceneNode {
     /**
      * Returns the parent node. Null if this is the root node, or a freshly constructed node which has not been added to a parent yet.
      */
-    readonly parent: SceneNode | null;
+    readonly parent: SceneNodeClass | null;
     /**
      * Returns a list of this node’s children. List is length 0 if the node has no children. The first child is lowest in the z order.
      * This list is not an Array, so you must use at(i) instead of [i] to access children by index. It has a number of Array-like methods such as forEach() for convenience, however.
@@ -629,7 +631,7 @@ export abstract class SceneNode {
 /**
  * Base class for nodes that have a stroke and/or fill. This includes leaf nodes such as Rectangle, as well as BooleanGroup which is a container node. If you create a shape node, it will not be visible unless you explicitly give it either a stroke or a fill.
  */
-export class GraphicNode extends SceneNode {
+export class GraphicNode extends SceneNodeClass {
     /**
      * The fill applied to this shape, if any. If this property is null or fillEnabled is false, no fill is drawn. Freshly created nodes have no fill by default.
      *
@@ -761,10 +763,10 @@ export class Artboard extends GraphicNode {
      * May include interactions that are impossible to trigger because the trigger node (or one of its ancestors) has `visible` = false.
      *
      * Note: currently, this API excludes any applicable keyboard/gamepad interactions.
-     * @see SceneNode.triggeredInteractions
+     * @see SceneNodeClass.triggeredInteractions
      * @see interactions.allInteractions
      */
-    readonly incomingInteractions: Array<{ triggerNode: SceneNode, interactions: Array<Interaction> }>;
+    readonly incomingInteractions: Array<{ triggerNode: SceneNodeClass, interactions: Array<Interaction> }>;
 
     /**
      * **Since**: XD 19
@@ -777,24 +779,24 @@ export class Artboard extends GraphicNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -976,24 +978,24 @@ export class BooleanGroup extends GraphicNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1170,32 +1172,32 @@ export class Text extends GraphicNode {
  *
  * In a Mask Group, the mask shape is included in the group’s children list, at the top of the z order. It is not visible - only its path outline is used, for clipping the group.
  */
-export class Group extends SceneNode {
+export class Group extends SceneNodeClass {
     /**
      * The mask shape applied to this group, if any. This object is also present in the group’s children list. Though it has no direct visual appearance of its own, the mask affects the entire groups’s appearance by clipping all its other content.
      */
-    readonly mask: SceneNode | null;
+    readonly mask: SceneNodeClass | null;
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1212,9 +1214,9 @@ export class Group extends SceneNode {
  *
  * Note that overrides vary somewhat in granularity. In some but not all cases, overriding one property may also prevent other properties on the same node from receiving future updates from the master instance.
  *
- * It is not currently possible for plugins to *create* a new component definition or a new SymbolInstance node, aside from using {@link commands.duplicate} to clone existing SymbolInstances.
+ * It is not currently possible for plugins to *create* a new component definition or a new SymbolInstance node, aside from using `require('commands').duplicate` to clone existing SymbolInstances.
  */
-export class SymbolInstance extends SceneNode {
+export class SymbolInstance extends SceneNodeClass {
     /**
      * An identifier unique within this document that is shared by all instances of the same component.
      */
@@ -1228,24 +1230,24 @@ export class SymbolInstance extends SceneNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1258,7 +1260,7 @@ export class SymbolInstance extends SceneNode {
  * Each grid cell is a Group that is an immediate child of the RepeatGrid. These groups are automatically created and destroyed as needed when the RepeatGrid is resized.
  * It is not currently possible for plugins to create a new RepeatGrid node, aside from using commands.duplicate to clone existing RepeatGrids.
  */
-export class RepeatGrid extends SceneNode {
+export class RepeatGrid extends SceneNodeClass {
     /**
      * Defines size of the RepeatGrid. Cells are created and destroyed as necessary to fill the current size. Cells that only partially fit will be clipped.
      */
@@ -1316,24 +1318,24 @@ export class RepeatGrid extends SceneNode {
 
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1344,33 +1346,35 @@ export class RepeatGrid extends SceneNode {
 /**
  * Container node whose content is linked to an external resource, such as Creative Cloud Libraries. It cannot be edited except by first ungrouping it, breaking this link.
  */
-export class LinkedGraphic extends SceneNode {
+export class LinkedGraphic extends SceneNodeClass {
 }
+
+export interface RootNode extends RootNodeClass {}
 
 /**
  * Class representing the root node of the document. All Artboards are children of this node, as well as any pasteboard content that does not lie within an Artboard. Artboards must be grouped contiguously at the bottom of this node’s z order. The root node has no visual appearance of its own.
  */
-export class RootNode extends SceneNode {
+declare class RootNodeClass extends SceneNodeClass {
     /**
      * Adds a child node to this container node. You can only add leaf nodes this way; to create structured subtrees of content, use commands.
-     * @param {SceneNode} node Child to add
+     * @param {SceneNodeClass} node Child to add
      * @param {number} index Optional: index to insert child at. Child is appended to end of children list (top of z order) otherwise.
      */
-    addChild(node: SceneNode, index?: number): void;
+    addChild(node: SceneNodeClass, index?: number): void;
 
     /**
      * Inserts a child node after the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately after this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately after this existing child
      */
-    addChildAfter(node: SceneNode, relativeTo: SceneNode): void;
+    addChildAfter(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Inserts a child node before the given reference node.
-     * @param {SceneNode} node Child to add
-     * @param {SceneNode} relativeTo New child is added immediately before this existing child
+     * @param {SceneNodeClass} node Child to add
+     * @param {SceneNodeClass} relativeTo New child is added immediately before this existing child
      */
-    addChildBefore(node: SceneNode, relativeTo: SceneNode): void;
+    addChildBefore(node: SceneNodeClass, relativeTo: SceneNodeClass): void;
 
     /**
      * Removes all children from this node. Equivalent to calling removeFromParent() on each child in turn, but faster.
@@ -1388,4 +1392,6 @@ export const selection: SceneNodeList;
  * **Since:** XD 14
  * Root node of the current document's scenegraph. Also available as the second argument passed to your plugin command handler function.
  */
-export const root: RootNode;
+export const root: RootNodeClass;
+
+export {};


### PR DESCRIPTION
### Contents of this Pull Request
This PR makes changes to
- [x] The typings in the `types` folder
- [ ] Configuration files (`tsconfig.json`, `jsconfig.json`, `.gitignore` etc.)
- [ ] The sample files (e.g., `sample.js`)
- [ ] The `README.md` or other files containing documentation
- [ ] Other

### Purpose of this Pull Request
Solve the problem with falsely exported classes `SceneNode` and `RootNode` of the `scenegraph` module.

### Issues resolved by this Pull Request
- fixes #56 
